### PR TITLE
Improve the build system a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /voskopus
 /oe-logs
 /oe-workdir
+/vicos-sdk

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ go_deps:
 
 vic-cloud: voskopusbuild go_deps
 	CGO_ENABLED=1 GOARM=7 GOARCH=arm \
-	CC=${HOME}/.anki/vicos-sdk/dist/5.3.0-r07/prebuilt/bin/arm-oe-linux-gnueabi-clang \
-	CXX=${HOME}/.anki/vicos-sdk/dist/5.3.0-r07/prebuilt/bin/arm-oe-linux-gnueabi-clang++ \
+	CC=$(PWD)/vicos-sdk/dist/5.3.0-r07/prebuilt/bin/arm-oe-linux-gnueabi-clang \
+	CXX=$(PWD)/vicos-sdk/dist/5.3.0-r07/prebuilt/bin/arm-oe-linux-gnueabi-clang++ \
 	PKG_CONFIG_PATH="$(PWD)/voskopus/built/armel/lib/pkgconfig" \
 	CGO_CFLAGS="-Wno-implicit-function-declaration -I$(PWD)/voskopus/built/armel/include -I$(PWD)/voskopus/built/armel/include/opus" \
 	CGO_CXXFLAGS="-stdlib=libc++ -std=c++11" \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Vector processing text all by himself.
 
 # Get deps
 
-**Install gcc, g++, cmake, make, automake, git, and wget.** After you do that, run this script to install the 5.2.1-r06 toolchain if you don't have it already:
+**Install gcc, g++, cmake, make, automake, git, and wget.** After you do that, run this script to install the 5.3.0-r07 toolchain if you don't have it already:
 
 ```
 ./get-deps.sh

--- a/build-voskopus.sh
+++ b/build-voskopus.sh
@@ -6,7 +6,7 @@ cd voskopus
 ORIGPATH="$(pwd)"
 
 #ARMT="$(pwd)/vic-toolchain/arm-linux-gnueabi/bin/arm-linux-gnueabi-"
-ARMT="$HOME/.anki/vicos-sdk/dist/5.3.0-r07/prebuilt/bin/arm-oe-linux-gnueabi-"
+ARMT="$(pwd)/../vicos-sdk/dist/5.3.0-r07/prebuilt/bin/arm-oe-linux-gnueabi-"
 
 #if [[ ! -f vic-toolchain ]]; then
 #    git clone https://github.com/kercre123/vic-toolchain --depth=1

--- a/get-deps.sh
+++ b/get-deps.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 
-if [[ ! -d ~/.anki/vicos-sdk/dist/5.3.0-r07 ]]; then
+TOOLCHAIN_VER="5.3.0-r07"
+OLD_TOOLCHAIN_VER="5.2.1-r06"
+
+if [[ -d vicos-sdk/dist/$OLD_TOOLCHAIN_VER/ ]]; then
+  echo "Removing old $OLD_TOOLCHAIN_VER toolchain"
+  rm -rf vicos-sdk/dist/$OLD_TOOLCHAIN_VER/
+fi
+
+if [[ ! -d vicos-sdk/dist/$TOOLCHAIN_VER/ ]]; then
   echo Getting deps...
-  mkdir ~/.anki/vicos-sdk/dist/5.3.0-r07
-  cd ~/.anki/vicos-sdk/dist/5.3.0-r07
-  wget https://froggitti.net/5.3.0-r07.tar.gz
-  gunzip 5.3.0-r07.tar.gz
-  tar -xvf 5.3.0-r07.tar
+  mkdir -p vicos-sdk/dist/$TOOLCHAIN_VER/
+  cd vicos-sdk/dist/$TOOLCHAIN_VER/
+  wget https://github.com/os-vector/wire-os-externals/releases/download/$TOOLCHAIN_VER/vicos-sdk_"$TOOLCHAIN_VER"_amd64-linux.tar.gz
+  tar -xzvf vicos-sdk_"$TOOLCHAIN_VER"_amd64-linux.tar.gz
+  rm vicos-sdk_"$TOOLCHAIN_VER"_amd64-linux.tar.gz
 else
-  echo You already have the 5.3.0-r07 toolchain installed. Exiting...
+  echo You already have the $TOOLCHAIN_VER toolchain installed. Exiting...
   exit
 fi


### PR DESCRIPTION
Have the sdk in the cloudless folder instead of .anki in home, autoremove old toolchains, use github for the toolchain link